### PR TITLE
Simplify about page and replace blog with Substack links

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -1,48 +1,16 @@
 ---
-layout: about
+layout: page
 title: about
 permalink: /
 subtitle: Software Engineer & ML Researcher
-
-profile:
-  align: right
-  image: prof_pic.jpg
-  image_circular: false # crops the image to make it circular
-  more_info: >
-    <p>MS in ECE, University of Delaware</p>
-    <p>Graduating May 2025</p>
-    <p>kamathhrishi@gmail.com</p>
-
-selected_papers: false # includes a list of papers marked as "selected={true}"
-social: true # includes social icons at the bottom of the page
-
-announcements:
-  enabled: false # includes a list of news items
-  scrollable: true # adds a vertical scroll bar if there are more than 3 news items
-  limit: 5 # leave blank to include all the news in the `_news` folder
-
-latest_posts:
-  enabled: true
-  scrollable: true # adds a vertical scroll bar if there are more than 3 new posts items
-  limit: 3 # leave blank to include all the blog posts
 ---
 
-I'm a software engineer and researcher specializing in machine learning, privacy-preserving systems, and MLOps. Currently pursuing my Master's in Electrical and Computer Engineering at the University of Delaware (graduating May 2025).
+<div style="text-align: center; max-width: 800px; margin: 0 auto;">
 
-## Professional Experience
-
-Most recently, I worked as a Research Engineer at Mbd.xyz where I deployed large language models using ONNXRuntime and developed recommendation system bridging techniques. Previously, I spent 2.5 years as a Software Engineer at Ederlabs, building backend systems and CI/CD pipelines.
-
-I'm a core contributor to OpenMined's PySyft and SyMPC projects, focusing on privacy-preserving machine learning. I also developed themarketcast.ai, an AI service that summarized S&P 500 earnings calls.
-
-## Technical Interests
-
-My work spans language models, reinforcement learning, computer vision, and MLOps principles. I'm particularly interested in systems that combine MLOps with practical applications in finance, security, and infrastructure.
-
-## Beyond Code
-
-I've been an active investor in Indian capital markets for five years using fundamental analysis. I'm passionate about capital markets strategy and building analytical tools that provide actionable insights beyond surface-level data summaries.
+I'm a software engineer and researcher specializing in machine learning, privacy-preserving systems, and MLOps. Currently pursuing my Master's in Electrical and Computer Engineering at the University of Delaware (graduating May 2025). Most recently, I worked as a Research Engineer at Mbd.xyz where I deployed large language models using ONNXRuntime and developed recommendation system bridging techniques. Previously, I spent 2.5 years as a Software Engineer at Ederlabs, building backend systems and CI/CD pipelines. I'm a core contributor to OpenMined's PySyft and SyMPC projects, focusing on privacy-preserving machine learning. I also developed themarketcast.ai, an AI service that summarized S&P 500 earnings calls. My work spans language models, reinforcement learning, computer vision, and MLOps principles. I'm particularly interested in systems that combine MLOps with practical applications in finance, security, and infrastructure. I've been an active investor in Indian capital markets for five years using fundamental analysis. I'm passionate about capital markets strategy and building analytical tools that provide actionable insights beyond surface-level data summaries.
 
 *Grew up playing Project IGI. Levelling up to play Project AGI.*
 
-Connect with me on [GitHub](https://github.com/kamathhrishi) and [Twitter](https://twitter.com/kamathhrishi).
+Connect with me on [GitHub](https://github.com/kamathhrishi) and [Twitter](https://twitter.com/kamathhrishi) | Email: kamathhrishi@gmail.com
+
+</div>

--- a/_pages/blog.md
+++ b/_pages/blog.md
@@ -1,196 +1,43 @@
 ---
-layout: default
+layout: page
 permalink: /blog/
 title: blog
 nav: true
 nav_order: 1
-pagination:
-  enabled: true
-  collection: posts
-  permalink: /page/:num/
-  per_page: 5
-  sort_field: date
-  sort_reverse: true
-  trail:
-    before: 1 # The number of links before the current page
-    after: 3 # The number of links after the current page
 ---
 
-<div class="post">
+## Writing on Tech, AI & Markets
 
-{% assign blog_name_size = site.blog_name | size %}
-{% assign blog_description_size = site.blog_description | size %}
+I write about financial markets, tech, and AI on [Substack](https://kamathhrishi.substack.com). Here are my recent posts:
 
-{% if blog_name_size > 0 or blog_description_size > 0 %}
+---
 
-  <div class="header-bar">
-    <h1>{{ site.blog_name }}</h1>
-    <h2>{{ site.blog_description }}</h2>
-  </div>
-  {% endif %}
+### [When to RAG, When to Go Agentic: UX Patterns for AI Response Modes](https://kamathhrishi.substack.com/p/when-to-rag-when-to-go-agentic-ux)
+*October 2025*
 
-{% if site.display_tags and site.display_tags.size > 0 or site.display_categories and site.display_categories.size > 0 %}
+Exploring UX patterns for different AI response modes - when to use RAG for speed vs going agentic for depth.
 
-  <div class="tag-category-list">
-    <ul class="p-0 m-0">
-      {% for tag in site.display_tags %}
-        <li>
-          <i class="fa-solid fa-hashtag fa-sm"></i> <a href="{{ tag | slugify | prepend: '/blog/tag/' | relative_url }}">{{ tag }}</a>
-        </li>
-        {% unless forloop.last %}
-          <p>&bull;</p>
-        {% endunless %}
-      {% endfor %}
-      {% if site.display_categories.size > 0 and site.display_tags.size > 0 %}
-        <p>&bull;</p>
-      {% endif %}
-      {% for category in site.display_categories %}
-        <li>
-          <i class="fa-solid fa-tag fa-sm"></i> <a href="{{ category | slugify | prepend: '/blog/category/' | relative_url }}">{{ category }}</a>
-        </li>
-        {% unless forloop.last %}
-          <p>&bull;</p>
-        {% endunless %}
-      {% endfor %}
-    </ul>
-  </div>
-  {% endif %}
+---
 
-{% assign featured_posts = site.posts | where: "featured", "true" %}
-{% if featured_posts.size > 0 %}
-<br>
+### [Why Your AI Search is Barely Scratching the Surface](https://kamathhrishi.substack.com/p/why-your-ai-search-is-barely-scratching)
+*August 2025*
 
-<div class="container featured-posts">
-{% assign is_even = featured_posts.size | modulo: 2 %}
-<div class="row row-cols-{% if featured_posts.size <= 2 or is_even == 0 %}2{% else %}3{% endif %}">
-{% for post in featured_posts %}
-<div class="col mb-4">
-<a href="{{ post.url | relative_url }}">
-<div class="card hoverable">
-<div class="row g-0">
-<div class="col-md-12">
-<div class="card-body">
-<div class="float-right">
-<i class="fa-solid fa-thumbtack fa-xs"></i>
-</div>
-<h3 class="card-title text-lowercase">{{ post.title }}</h3>
-<p class="card-text">{{ post.description }}</p>
+And why ChatGPT can't give you a complete spreadsheet of competitors, employees, or even jobs.
 
-                    {% if post.external_source == blank %}
-                      {% assign read_time = post.content | number_of_words | divided_by: 180 | plus: 1 %}
-                    {% else %}
-                      {% assign read_time = post.feed_content | strip_html | number_of_words | divided_by: 180 | plus: 1 %}
-                    {% endif %}
-                    {% assign year = post.date | date: "%Y" %}
+---
 
-                    <p class="post-meta">
-                      {{ read_time }} min read &nbsp; &middot; &nbsp;
-                      <a href="{{ year | prepend: '/blog/' | relative_url }}">
-                        <i class="fa-solid fa-calendar fa-sm"></i> {{ year }} </a>
-                    </p>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </a>
-        </div>
-      {% endfor %}
-      </div>
-    </div>
-    <hr>
+### [Why Alpha Lies in Open Source Market Terminal](https://kamathhrishi.substack.com/p/why-alpha-lies-in-open-source-market)
+*August 2025*
 
-{% endif %}
+Exploring customizable financial dashboards and alternative data sources for finding market edge.
 
-  <ul class="post-list">
+---
 
-    {% if page.pagination.enabled %}
-      {% assign postlist = paginator.posts %}
-    {% else %}
-      {% assign postlist = site.posts %}
-    {% endif %}
+### [RAG is Never Dead](https://kamathhrishi.substack.com/p/rag-is-never-dead)
+*August 2025*
 
-    {% for post in postlist %}
+Or how long context LLMs don't kill retrieval - why retrieval-augmented generation remains essential.
 
-    {% if post.external_source == blank %}
-      {% assign read_time = post.content | number_of_words | divided_by: 180 | plus: 1 %}
-    {% else %}
-      {% assign read_time = post.feed_content | strip_html | number_of_words | divided_by: 180 | plus: 1 %}
-    {% endif %}
-    {% assign year = post.date | date: "%Y" %}
-    {% assign tags = post.tags | join: "" %}
-    {% assign categories = post.categories | join: "" %}
+---
 
-    <li>
-
-{% if post.thumbnail %}
-
-<div class="row">
-          <div class="col-sm-9">
-{% endif %}
-        <h3>
-        {% if post.redirect == blank %}
-          <a class="post-title" href="{{ post.url | relative_url }}">{{ post.title }}</a>
-        {% elsif post.redirect contains '://' %}
-          <a class="post-title" href="{{ post.redirect }}" target="_blank">{{ post.title }}</a>
-          <svg width="2rem" height="2rem" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg">
-            <path d="M17 13.5v6H5v-12h6m3-3h6v6m0-6-9 9" class="icon_svg-stroke" stroke="#999" stroke-width="1.5" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round"></path>
-          </svg>
-        {% else %}
-          <a class="post-title" href="{{ post.redirect | relative_url }}">{{ post.title }}</a>
-        {% endif %}
-      </h3>
-      <p>{{ post.description }}</p>
-      <p class="post-meta">
-        {{ read_time }} min read &nbsp; &middot; &nbsp;
-        {{ post.date | date: '%B %d, %Y' }}
-        {% if post.external_source %}
-        &nbsp; &middot; &nbsp; {{ post.external_source }}
-        {% endif %}
-      </p>
-      <p class="post-tags">
-        <a href="{{ year | prepend: '/blog/' | relative_url }}">
-          <i class="fa-solid fa-calendar fa-sm"></i> {{ year }} </a>
-
-          {% if tags != "" %}
-          &nbsp; &middot; &nbsp;
-            {% for tag in post.tags %}
-            <a href="{{ tag | slugify | prepend: '/blog/tag/' | relative_url }}">
-              <i class="fa-solid fa-hashtag fa-sm"></i> {{ tag }}</a>
-              {% unless forloop.last %}
-                &nbsp;
-              {% endunless %}
-              {% endfor %}
-          {% endif %}
-
-          {% if categories != "" %}
-          &nbsp; &middot; &nbsp;
-            {% for category in post.categories %}
-            <a href="{{ category | slugify | prepend: '/blog/category/' | relative_url }}">
-              <i class="fa-solid fa-tag fa-sm"></i> {{ category }}</a>
-              {% unless forloop.last %}
-                &nbsp;
-              {% endunless %}
-              {% endfor %}
-          {% endif %}
-    </p>
-
-{% if post.thumbnail %}
-
-</div>
-
-  <div class="col-sm-3">
-    <img class="card-img" src="{{ post.thumbnail | relative_url }}" style="object-fit: cover; height: 90%" alt="image">
-  </div>
-</div>
-{% endif %}
-    </li>
-
-    {% endfor %}
-
-  </ul>
-
-{% if page.pagination.enabled %}
-{% include pagination.liquid %}
-{% endif %}
-
-</div>
+**Subscribe on [Substack](https://kamathhrishi.substack.com) for more posts on software engineering, AI, and financial markets.**


### PR DESCRIPTION
- Removed Einstein profile image from about page
- Converted about content to single centered paragraph
- Replaced full blog functionality with simple links to Substack posts
- Blog page now shows 4 recent Substack articles with descriptions and links
- Added email contact info to about page