### PR TITLE
Add hide_title option to suppress page headings while keeping navigation

### DIFF
--- a/_layouts/page.liquid
+++ b/_layouts/page.liquid
@@ -10,7 +10,9 @@ layout: default
 
 <div class="post">
   <header class="post-header">
-    <h1 class="post-title">{{ page.title }}</h1>
+    {% unless page.hide_title %}
+      <h1 class="post-title">{{ page.title }}</h1>
+    {% endunless %}
     <p class="post-description">{{ page.description }}</p>
   </header>
 

--- a/_pages/blog.md
+++ b/_pages/blog.md
@@ -4,6 +4,7 @@ permalink: /blog/
 title: blog
 nav: true
 nav_order: 2
+hide_title: true
 ---
 
 ## Writing on Tech, AI & Markets

--- a/_pages/projects.md
+++ b/_pages/projects.md
@@ -4,6 +4,7 @@ title: projects
 permalink: /projects/
 nav: true
 nav_order: 1
+hide_title: true
 ---
 
 <h2 style="text-align: center; font-weight: bold; margin: 40px 0 30px 0;">Personal Projects</h2>


### PR DESCRIPTION
- Modified page layout to conditionally display title based on hide_title flag
- Added hide_title: true to projects and blog pages
- Navigation links remain functional with title field present