### PR TITLE
Reorganize about page to emphasize StrataLens AI as most recent work

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -7,11 +7,11 @@ permalink: /
 <div style="max-width: 900px; margin: 0 auto; padding: 40px 20px;">
 
 <p style="text-align: justify; line-height: 1.8; margin-bottom: 25px;">
-Hello, I'm Hrishikesh. Software engineer with experience building full-stack applications and AI agents. Previously core contributor to <strong>PySyft</strong>, one of the most widely used privacy-preserving machine learning libraries, and founding engineer at an Accel-backed startup in India. I recently completed my Master's in Electrical and Computer Engineering at the <strong>University of Delaware</strong>, where I worked on research in LLM code generation and hardware security (logic locking). Before that, I spent 2.5 years as a <strong>Software Engineer at Ederlabs</strong>, building backend systems and CI/CD pipelines.
+Hello, I'm Hrishikesh. Software engineer with experience building full-stack applications and AI agents. Most recently, I built <strong>StrataLens AI</strong>, an equity research platform for financial analysts that uses a RAG agent to answer questions from SEC filings, earnings calls, and news—scoring 85% on FinanceBench for SEC filing queries. Previously, I was a core contributor to <strong>PySyft</strong>, one of the most widely used privacy-preserving machine learning libraries, and founding engineer at an Accel-backed startup in India. I recently completed my Master's in Electrical and Computer Engineering at the <strong>University of Delaware</strong> with research in LLM code generation and hardware security.
 </p>
 
 <p style="text-align: justify; line-height: 1.8; margin-bottom: 25px;">
-I've been an active investor in Indian capital markets for five years, which sparked my passion for building tools that go beyond surface-level data summaries. Most recently, I built <strong>StrataLens AI</strong>, an equity research platform with agentic RAG pipelines for earnings calls and SEC filings. While I decided not to continue it as a product, I'm still actively working on it as a project alongside <strong>themarketcast.ai</strong>, a platform for analyzing private capital formation trends. My work spans language models, reinforcement learning, computer vision, and MLOps—particularly where they intersect with finance, security, and infrastructure.
+I've been an active investor in Indian capital markets for five years, which sparked my passion for building tools that go beyond surface-level data summaries. My work spans language models, reinforcement learning, computer vision, and MLOps—particularly where they intersect with finance, security, and infrastructure.
 </p>
 
 <p style="text-align: justify; line-height: 1.8; margin-bottom: 35px;">

--- a/_pages/projects.md
+++ b/_pages/projects.md
@@ -12,7 +12,7 @@ hide_title: true
 ### StrataLens AI
 Link: [stratalens.ai](https://stratalens.ai)
 
-Built equity research platform using **FastAPI**, **React**, **PostgreSQL**, **Redis**, and **Logfire** for observability. Implemented latency-optimized agentic RAG pipeline using **Groq** inference (**OpenAI 20B OSS**) and **GPT-4.1 Nano** with **pgvector** for vector retrieval across 10,000+ earnings calls (2022-2025). Building agentic RAG pipeline for SEC filings achieving ~85% accuracy on FinanceBench benchmark with LLM-as-judge evaluation. Developed text-to-SQL stock screener and market data analysis tool using **DuckDB** for natural language financial queries.
+Built equity research platform using **FastAPI**, **React**, **TypeScript**, **PostgreSQL**, **Redis**, and **Logfire** for observability. Developed latency-optimized agentic RAG system using **Qwen3-235B** that synthesizes earnings calls, SEC filings, and real-time news via **Tavily** to answer complex financial queries. Built SEC filings RAG pipeline achieving ~85% accuracy on FinanceBench benchmark with LLM-as-judge evaluation. Developed text-to-SQL stock screener and market data analysis tool using **DuckDB** for natural language financial queries.
 
 ---
 


### PR DESCRIPTION
- Put StrataLens AI at the top of about page with key achievement (85% FinanceBench score)
- Updated StrataLens AI project description with latest tech stack (Qwen3-235B, Tavily, TypeScript)
- Streamlined about page flow to highlight most recent work first